### PR TITLE
Update FunkAnaSkriptSS2017.tex

### DIFF
--- a/FunkAnaSkriptSS2017.tex
+++ b/FunkAnaSkriptSS2017.tex
@@ -118,7 +118,7 @@ Eine Norm efüllt zusätzlich noch die Bedingung, dass sie nur dann verschwindet
 		\item \textbf{essentiell beschränkt} - 
 					Eine Funktion $f: \Omega \rightarrow \R$ heißt essentiell beschränkt, falls 
 					$$\underset{x\in\Omega}{\ess \sup} |f(x)| := \underset{{\mu(N) = 0}}{ \inf_{N \in \hA} }  
-					\sup_{x\in \Omega\backslash N} < \infty$$
+					\sup_{x\in \Omega\backslash N} |f(x)| < \infty$$
 					oder auch: f ist fast überall beschränkt. 
 					Ein Beispiel ist $f(x) : = x\cdot \chi_\Q(x)$ und $\mu = \lambda$, da $f$ nur auf $\Q$ nicht null ist, und $\Q$ ist Lesbesgue-Nullmenge. 
 


### PR DESCRIPTION
Fehlendes |f(x)| bei essentiell Beschränkt hinzugefügt.